### PR TITLE
Remove hard-coded username for step3 submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,9 @@ The other arguments should be self-explanatory. They are also documented [here](
 
 ## To process only step3
 
-It is also possible to run only the last step (reco with TICL).
+It is possible to run only the last step (reco with TICL).
 
-Before starting the submission, some manual operations are needed in the ```condor/batchScript_onlystep3_template.sh``` file. The storage and local folder should be modified to fit your needs and setup.
-
-```bash condor/submit_onlystep3.sh``` is the command to run to setup the production and submit condor jobs.
-```bash condor/submit_onlystep3.sh``` needs some arguments:
-* ```-f```: name of the folder in the storage area where step2 files (in a proper ```step2``` folder) are stored
+```bash condor/submit_onlystep3.sh``` is the command to run to setup the production and submit condor jobs. It requires the following arguments:
+* ```-f```: folder name in the storage area where step2 files (in a proper ```step2/``` folder) are stored
 * ```-s```: name of the folder where step3 files will be stored
+It is assumed the storage folder is ```/data_CMS/cms/${USER}/```.

--- a/condor/batchScript_onlystep3_template.sh
+++ b/condor/batchScript_onlystep3_template.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-storage=/grid_mnt/data__data.polcms/cms/tarabini/FOLDER
-local=/grid_mnt/vol_home/llr/cms/tarabini/CMSSW_12_6_0_pre4/src/HGCALprod
+storage=/data_CMS/cms/${USER}/FOLDER
+local=/grid_mnt/vol_home/llr/cms/${USER}/CMSSW_12_6_0_pre4/src/HGCALprod
 folder=$PWD
 
 source /cvmfs/cms.cern.ch/cmsset_default.sh

--- a/condor/step2_fileList_generator.py
+++ b/condor/step2_fileList_generator.py
@@ -12,7 +12,7 @@ parser.add_option('',   '--path',  dest='PATH',  type='string',default='',   hel
 (opt, args) = parser.parse_args()
 
 fileList = ''
-fpath = '/grid_mnt/data__data.polcms/cms/tarabini/'+opt.PATH+'/step2/'
+fpath = "/data_CMS/cms/" + os.environ['USER'] + "/" + opt.PATH + "/step2/"
 for filename in os.listdir(fpath):
     inFile = ROOT.TFile.Open(fpath+filename ,"READ")
     if(inFile.GetListOfKeys().Contains('Events')):


### PR DESCRIPTION
After this PR no manual adaption of submission files will be required when submitting only the step3. The username is picked automatically.

Tested with:

```
bash condor/submit_onlystep3.sh -f SinglePion_0PU_10En200_30Jun -s step3_linking
```